### PR TITLE
21 allow save config to save stepper settings

### DIFF
--- a/extras/chopper_tune.py
+++ b/extras/chopper_tune.py
@@ -1840,6 +1840,9 @@ class ChopperTune:
                 f"driver={self.driver} "
                 f"sense_resistor={self.sense_resistor}"
             )
+        else:
+            # Save best parameters
+            self.save_configs(best_parameters)
 
         # reset number of samples
         self.number_of_samples = 0


### PR DESCRIPTION
Settings are now saved to the `printer.cfg`.